### PR TITLE
change dim checking procedure in find.my.case().

### DIFF
--- a/R/LifeTable.R
+++ b/R/LifeTable.R
@@ -269,10 +269,28 @@ find.my.case <- function(Dx = NULL,
   }
 
   X       <- input[L1][[1]]
+  
+  if (length(dim(X)) == 1){
+    # TR changed here:
+    # The following input isn't detected with is.vector()
+    # X = structure(c(0.0036542739116619, 0.000150960486092765, 2.77881983521598e-05, 
+    # 0.000136941279579316, 0.00018946827083136, 0.00026606712873658, 
+    # 0.000258838755220895, 0.000557913403869528, 0.000665917509468515, 
+    # 0.00114979916336982, 0.0021040113433655, 0.00384681333263752, 
+    # 0.00632225868307671, 0.00937214337262448, 0.0154497258185624, 
+    # 0.023117866694913, 0.0363617070194365, 0.0609184108563059, 0.120398389987367, 
+    # 0.221461187214612, 0.420152946468736), .Dim = 21L)
+    # nLT would come as NA
+    # and iclass would be array
+    X <- c(X)
+  }
+  
   nLT     <- 1
   LTnames <- NA
 
-  if (!is.vector(X)) {
+  # TR: change from !is.vector
+  if (length(dim(X)) == 2 ) {
+    
     nLT     <- ncol(X)     # number of LTs to be created
     LTnames <- colnames(X) # the names to be assigned to LTs
   }

--- a/R/LifeTable.R
+++ b/R/LifeTable.R
@@ -296,7 +296,8 @@ find.my.case <- function(Dx = NULL,
   }
 
   out <- list(case = my_case,
-              iclass = class(X),
+              iclass = class(X), # TR: if inputs are matrix,
+                                 # then this is two elements
               nLT = nLT,
               LTnames = LTnames)
   return(out)

--- a/R/MortalityLaw_main.R
+++ b/R/MortalityLaw_main.R
@@ -138,6 +138,11 @@ MortalityLaw <- function(x, Dx = NULL, Ex = NULL, mx = NULL, qx = NULL,
   input   <- c(as.list(environment()))
   K <- find.my.case(Dx, Ex, mx, qx)
 
+  # TR: if inputs are matrix, then we have class matrix, array, and this 
+  # throws a warning. If we have a dim attribute then this won't work. Even
+  # if it's a 1-column matrix (class =array) or a single-dim length-attribute vector
+  # (also array!). Both of those cases are probably things we want to treat as 
+  # vectors!
   if (K$iclass == "numeric") {
     check.MortalityLaw(input) # Check input
     if (show) {pb <- startpb(0, 4); on.exit(closepb(pb)); setpb(pb, 1)} # Set progress bar


### PR DESCRIPTION
The following vector-ish thing isn't detected with `is.vector()`, and can lead to mishandling of `nL` and `iclass` outputs from `find.my.case()`. So I made little changes to dimension checking, added a coercion for the below object. My own detection strategy could be flawed, but the given case succeeds and all tests pass with this change.
```
  X = structure(c(0.0036542739116619, 0.000150960486092765, 2.77881983521598e-05, 
  0.000136941279579316, 0.00018946827083136, 0.00026606712873658, 
  0.000258838755220895, 0.000557913403869528, 0.000665917509468515, 
  0.00114979916336982, 0.0021040113433655, 0.00384681333263752, 
  0.00632225868307671, 0.00937214337262448, 0.0154497258185624, 
  0.023117866694913, 0.0363617070194365, 0.0609184108563059, 0.120398389987367, 
  0.221461187214612, 0.420152946468736), .Dim = 21L)
```
 